### PR TITLE
Allow larger responses to be stored in ssi variables

### DIFF
--- a/modules/homepage.nix
+++ b/modules/homepage.nix
@@ -45,6 +45,7 @@ mkTrivialModule {
     extraConfig = ''
       ssi on;
       ssi_types *;
+      subrequest_output_buffer_size 64k;
     '';
     locations."~ /https://([^/\\n]+)/(.*)" = {
       proxyPass = "https://$1/$2?$args";
@@ -70,6 +71,7 @@ mkTrivialModule {
     extraConfig = ''
       ssi on;
       ssi_types *;
+      subrequest_output_buffer_size 64k;
     '';
     locations."~ /https://([^/\\n]+)/(.*)" = {
       proxyPass = "https://$1/$2?$args";


### PR DESCRIPTION
Default was 4k or 8k depending on the architecture.