### PR TITLE
Update KoMapedia input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -119,11 +119,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699141113,
-        "narHash": "sha256-+yCTtifwtJCa3TW0oV4N15kHn7E9Ucp7b8lC0cFe8Eo=",
+        "lastModified": 1699620339,
+        "narHash": "sha256-Ccwv6WZVzNDowQWADZ58yioDizZKyvSP5aqCdw4pxDs=",
         "owner": "Die-KoMa",
         "repo": "mediawiki",
-        "rev": "f8594fd3a0512fda3f0d35a3baa1d841e9a0c78b",
+        "rev": "bbd7ce189904943b118a82599a6c25d69d8e441e",
         "type": "github"
       },
       "original": {
@@ -178,11 +178,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698942558,
-        "narHash": "sha256-/UmnB+mEd6Eg3mJBrAgqRcyZX//RSjHphcCO7Ig9Bpk=",
+        "lastModified": 1699291058,
+        "narHash": "sha256-5ggduoaAMPHUy4riL+OrlAZE14Kh7JWX4oLEs22ZqfU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "621f51253edffa1d6f08d5fce4f08614c852d17e",
+        "rev": "41de143fda10e33be0f47eab2bfe08a50f234267",
         "type": "github"
       },
       "original": {
@@ -375,11 +375,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699021419,
-        "narHash": "sha256-oy2j2OHXYcckifASMeZzpmbDLSvobMGt0V/RvoDotF4=",
+        "lastModified": 1699311858,
+        "narHash": "sha256-W/sQrghPAn5J9d+9kMnHqi4NPVWVpy0V/qzQeZfS/dM=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "275b28593ef3a1b9d05b6eeda3ddce2f45f5c06f",
+        "rev": "664187539871f63857bda2d498f452792457b998",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'komapedia':
    'github:Die-KoMa/mediawiki/f8594fd3a0512fda3f0d35a3baa1d841e9a0c78b' (2023-11-04)
  → 'github:Die-KoMa/mediawiki/bbd7ce189904943b118a82599a6c25d69d8e441e' (2023-11-10)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/621f51253edffa1d6f08d5fce4f08614c852d17e' (2023-11-02)
  → 'github:NixOS/nixpkgs/41de143fda10e33be0f47eab2bfe08a50f234267' (2023-11-06)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/275b28593ef3a1b9d05b6eeda3ddce2f45f5c06f' (2023-11-03)
  → 'github:Mic92/sops-nix/664187539871f63857bda2d498f452792457b998' (2023-11-06)

Fixes #27.
Fixes #28.