### PR TITLE
Use a persistent cache backend for the KoMapedia session cache

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -97,11 +97,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695108154,
-        "narHash": "sha256-gSg7UTVtls2yO9lKtP0yb66XBHT1Fx5qZSZbGMpSn2c=",
+        "lastModified": 1699748081,
+        "narHash": "sha256-MOmMapBydd7MTjhX4eeQZzKlCABWw8W6iSHSG4OeFKE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "07682fff75d41f18327a871088d20af2710d4744",
+        "rev": "04bac349d585c9df38d78e0285b780a140dc74a4",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699620339,
-        "narHash": "sha256-Ccwv6WZVzNDowQWADZ58yioDizZKyvSP5aqCdw4pxDs=",
+        "lastModified": 1699906320,
+        "narHash": "sha256-ZVzG+0iCkIC38dY4+kGYOoBNAESOsgZjoppl6Fj0F1Y=",
         "owner": "Die-KoMa",
         "repo": "mediawiki",
-        "rev": "bbd7ce189904943b118a82599a6c25d69d8e441e",
+        "rev": "969555e0c87113fcad07ddf25845559ad7613e2d",
         "type": "github"
       },
       "original": {
@@ -178,11 +178,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699291058,
-        "narHash": "sha256-5ggduoaAMPHUy4riL+OrlAZE14Kh7JWX4oLEs22ZqfU=",
+        "lastModified": 1699596684,
+        "narHash": "sha256-XSXP8zjBZJBVvpNb2WmY0eW8O2ce+sVyj1T0/iBRIvg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "41de143fda10e33be0f47eab2bfe08a50f234267",
+        "rev": "da4024d0ead5d7820f6bd15147d3fe2a0c0cec73",
         "type": "github"
       },
       "original": {
@@ -375,11 +375,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699311858,
-        "narHash": "sha256-W/sQrghPAn5J9d+9kMnHqi4NPVWVpy0V/qzQeZfS/dM=",
+        "lastModified": 1699770333,
+        "narHash": "sha256-tWIifHuqPZKCuAVjewewX/LyC6LCf5dsIkyDHlXr7DM=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "664187539871f63857bda2d498f452792457b998",
+        "rev": "2fc3c9edc3029ed396ec917f39a7253acc3d8999",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'homemanager':
    'github:nix-community/home-manager/07682fff75d41f18327a871088d20af2710d4744' (2023-09-19)
  → 'github:nix-community/home-manager/04bac349d585c9df38d78e0285b780a140dc74a4' (2023-11-12)
• Updated input 'komapedia':
    'github:Die-KoMa/mediawiki/bbd7ce189904943b118a82599a6c25d69d8e441e' (2023-11-10)
  → 'github:Die-KoMa/mediawiki/969555e0c87113fcad07ddf25845559ad7613e2d' (2023-11-13)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/41de143fda10e33be0f47eab2bfe08a50f234267' (2023-11-06)
  → 'github:NixOS/nixpkgs/da4024d0ead5d7820f6bd15147d3fe2a0c0cec73' (2023-11-10)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/664187539871f63857bda2d498f452792457b998' (2023-11-06)
  → 'github:Mic92/sops-nix/2fc3c9edc3029ed396ec917f39a7253acc3d8999' (2023-11-12)