### PR TITLE
KoMapedia: enable subpages for Mainspace

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -97,11 +97,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699748081,
-        "narHash": "sha256-MOmMapBydd7MTjhX4eeQZzKlCABWw8W6iSHSG4OeFKE=",
+        "lastModified": 1700392168,
+        "narHash": "sha256-v5LprEFx3u4+1vmds9K0/i7sHjT0IYGs7u9v54iz/OA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "04bac349d585c9df38d78e0285b780a140dc74a4",
+        "rev": "28535c3a34d79071f2ccb68671971ce0c0984d7e",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699952962,
-        "narHash": "sha256-IuhWLF5k9WvkRyRZn/TzeSuFIUFOHZKaQxeq4/uTBDE=",
+        "lastModified": 1700526183,
+        "narHash": "sha256-veJWl07AllbM5UryyU4tgnIdKMPqXsS3GKaIVuDahvE=",
         "owner": "Die-KoMa",
         "repo": "mediawiki",
-        "rev": "a85ce3a3dc2df8cce958d12a80e089e34734db27",
+        "rev": "293639a26058751e4c04534f13072a5c1c38d861",
         "type": "github"
       },
       "original": {
@@ -178,11 +178,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699596684,
-        "narHash": "sha256-XSXP8zjBZJBVvpNb2WmY0eW8O2ce+sVyj1T0/iBRIvg=",
+        "lastModified": 1700403855,
+        "narHash": "sha256-Q0Uzjik9kUTN9pd/kp52XJi5kletBhy29ctBlAG+III=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da4024d0ead5d7820f6bd15147d3fe2a0c0cec73",
+        "rev": "0c5678df521e1407884205fe3ce3cf1d7df297db",
         "type": "github"
       },
       "original": {
@@ -375,11 +375,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699951338,
-        "narHash": "sha256-1GeczM7XfgHcYGYiYNcdwSFu3E62vmh4d7mffWZvyzE=",
+        "lastModified": 1700362823,
+        "narHash": "sha256-/H7XgvrYM0IbkpWkcdfkOH0XyBM5ewSWT1UtaLvOgKY=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "0e3a94167dcd10a47b89141f35b2ff9e04b34c46",
+        "rev": "49a87c6c827ccd21c225531e30745a9a6464775c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'homemanager':
    'github:nix-community/home-manager/04bac349d585c9df38d78e0285b780a140dc74a4' (2023-11-12)
  → 'github:nix-community/home-manager/28535c3a34d79071f2ccb68671971ce0c0984d7e' (2023-11-19)
• Updated input 'komapedia':
    'github:Die-KoMa/mediawiki/a85ce3a3dc2df8cce958d12a80e089e34734db27' (2023-11-14)
  → 'github:Die-KoMa/mediawiki/293639a26058751e4c04534f13072a5c1c38d861' (2023-11-21)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/da4024d0ead5d7820f6bd15147d3fe2a0c0cec73' (2023-11-10)
  → 'github:NixOS/nixpkgs/0c5678df521e1407884205fe3ce3cf1d7df297db' (2023-11-19)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/0e3a94167dcd10a47b89141f35b2ff9e04b34c46' (2023-11-14)
  → 'github:Mic92/sops-nix/49a87c6c827ccd21c225531e30745a9a6464775c' (2023-11-19)