### PR TITLE
Upgrade to NixOS-26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -238,25 +238,7 @@
     },
     "flake-utils_2": {
       "inputs": {
-        "systems": "systems_4"
-      },
-      "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "inputs": {
-        "systems": "systems_5"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1694529238,
@@ -338,11 +320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777138174,
-        "narHash": "sha256-EHnqtgy1NzEIMXvxsWspqo63bcEMy/YFfQ7FRctC0qs=",
+        "lastModified": 1781969538,
+        "narHash": "sha256-STA3RBxoGcJH4bhIer0fQ7VgLSE84ynfLijFsQhUxKA=",
         "owner": "Die-KoMa",
         "repo": "mediawiki",
-        "rev": "70db6d80fb8237519dfb2bdd2d99aa8a18345edb",
+        "rev": "6367b29017a68a9aa27f074a5e826778fb712c20",
         "type": "github"
       },
       "original": {
@@ -362,8 +344,8 @@
         ],
         "pre-commit-hooks": "pre-commit-hooks_2",
         "rust-overlay": "rust-overlay_2",
-        "treefmt-nix": "treefmt-nix_3",
-        "utils": "utils_3"
+        "treefmt-nix": "treefmt-nix_2",
+        "utils": "utils_2"
       },
       "locked": {
         "lastModified": 1765638808,
@@ -384,44 +366,19 @@
         "nixpkgs": [
           "komapedia",
           "nixpkgs"
-        ],
-        "poetry2nix": "poetry2nix",
-        "utils": "utils_2"
-      },
-      "locked": {
-        "lastModified": 1765631016,
-        "narHash": "sha256-CvO45nL4/5ooYp5Pf6PpnlM/BSMs9BBWKaPSWjjP/LE=",
-        "owner": "Die-KoMa",
-        "repo": "mediawiki-extdist",
-        "rev": "b438f8ab8657f0388ea31864e026dbe8c006a30e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Die-KoMa",
-        "repo": "mediawiki-extdist",
-        "type": "github"
-      }
-    },
-    "nix-github-actions": {
-      "inputs": {
-        "nixpkgs": [
-          "komapedia",
-          "mediawiki-extdist",
-          "poetry2nix",
-          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1729742964,
-        "narHash": "sha256-B4mzTcQ0FZHdpeWcpDYPERtyjJd/NIuaQ9+BV1h+MpA=",
-        "owner": "nix-community",
-        "repo": "nix-github-actions",
-        "rev": "e04df33f62cdcf93d73e9a04142464753a16db67",
+        "lastModified": 1781968485,
+        "narHash": "sha256-Up1asfQezGmF9q12gkFBXHp0f6blb6j5N7V9F1gMQhw=",
+        "owner": "Die-KoMa",
+        "repo": "mediawiki-extdist",
+        "rev": "e678126d857f8c1174ab11603d228c9f54383d5f",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
-        "repo": "nix-github-actions",
+        "owner": "Die-KoMa",
+        "repo": "mediawiki-extdist",
         "type": "github"
       }
     },
@@ -442,34 +399,28 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779102034,
-        "narHash": "sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "687f05a9184cad4eaf905c48b63649e3a86f5433",
-        "type": "github"
+        "lastModified": 1781216227,
+        "narHash": "sha256-PoRRDfm1khYEJCk5KyX4Snud03VzRcmxKil5n6drTI0=",
+        "rev": "a0374025a863d007d98e3297f6aa46cc3141c2f0",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/26.05/nixos-26.05.1947.a0374025a863/nixexprs.tar.xz?lastModified=1781216227&rev=a0374025a863d007d98e3297f6aa46cc3141c2f0"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.11",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1779543187,
-        "narHash": "sha256-6SjdsouT54k1+/DyBqTJwdFlja4RBNq9jP9N+8kBIa0=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "19942a940b16e7e7285e3cf58f09fa1aeb2f90cd",
-        "type": "github"
+        "lastModified": 1781577229,
+        "narHash": "sha256-rcUHdUtJEvMdNEl2Wq+YpHraHKfcer3KsBscpZEF2Yg=",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1017464.567a49d1913c/nixexprs.tar.xz?lastModified=1781577229&rev=567a49d1913ce81ac6e9582e3553dd90a955875f"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable-small",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
     "nixpkgs_2": {
@@ -485,37 +436,6 @@
         "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "poetry2nix": {
-      "inputs": {
-        "flake-utils": [
-          "komapedia",
-          "mediawiki-extdist",
-          "utils",
-          "flake-utils"
-        ],
-        "nix-github-actions": "nix-github-actions",
-        "nixpkgs": [
-          "komapedia",
-          "mediawiki-extdist",
-          "nixpkgs"
-        ],
-        "systems": "systems_3",
-        "treefmt-nix": "treefmt-nix_2"
-      },
-      "locked": {
-        "lastModified": 1743690424,
-        "narHash": "sha256-cX98bUuKuihOaRp8dNV1Mq7u6/CQZWTPth2IJPATBXc=",
-        "owner": "nix-community",
-        "repo": "poetry2nix",
-        "rev": "ce2369db77f45688172384bbeb962bc6c2ea6f94",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "poetry2nix",
         "type": "github"
       }
     },
@@ -652,11 +572,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777944972,
-        "narHash": "sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8=",
+        "lastModified": 1781943681,
+        "narHash": "sha256-NFHmA7H47adqiyp+0iEOyZOQhmigDqA/NBAlf4imB6U=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c591bf665727040c6cc5cb409079acb22dcce33c",
+        "rev": "420f8d2e9882911f65cfac15cc706f639ba96cca",
         "type": "github"
       },
       "original": {
@@ -710,36 +630,6 @@
         "type": "github"
       }
     },
-    "systems_4": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_5": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
@@ -762,29 +652,6 @@
       }
     },
     "treefmt-nix_2": {
-      "inputs": {
-        "nixpkgs": [
-          "komapedia",
-          "mediawiki-extdist",
-          "poetry2nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1730120726,
-        "narHash": "sha256-LqHYIxMrl/1p3/kvm2ir925tZ8DkI0KA10djk8wecSk=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "9ef337e492a5555d8e17a51c911ff1f02635be15",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "treefmt-nix_3": {
       "inputs": {
         "nixpkgs": [
           "kommemeorate",
@@ -826,24 +693,6 @@
     "utils_2": {
       "inputs": {
         "flake-utils": "flake-utils_2"
-      },
-      "locked": {
-        "lastModified": 1738591040,
-        "narHash": "sha256-4WNeriUToshQ/L5J+dTSWC5OJIwT39SEP7V7oylndi8=",
-        "owner": "gytis-ivaskevicius",
-        "repo": "flake-utils-plus",
-        "rev": "afcb15b845e74ac5e998358709b2b5fe42a948d1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "gytis-ivaskevicius",
-        "repo": "flake-utils-plus",
-        "type": "github"
-      }
-    },
-    "utils_3": {
-      "inputs": {
-        "flake-utils": "flake-utils_3"
       },
       "locked": {
         "lastModified": 1738591040,

--- a/flake.lock
+++ b/flake.lock
@@ -412,15 +412,15 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-rcUHdUtJEvMdNEl2Wq+YpHraHKfcer3KsBscpZEF2Yg=",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "lastModified": 1782014548,
+        "narHash": "sha256-P/WemHI+wVWyn4h1n5FbwGqgSUOX4t0/6GiVM44LoMs=",
+        "rev": "72349305fb839e27697873de7a4ce3a98c378f48",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1017464.567a49d1913c/nixexprs.tar.xz?lastModified=1781577229&rev=567a49d1913ce81ac6e9582e3553dd90a955875f"
+        "url": "https://releases.nixos.org/nixos/unstable-small/nixos-26.11pre1019718.72349305fb83/nixexprs.tar.xz?lastModified=1782014548&rev=72349305fb839e27697873de7a4ce3a98c378f48"
       },
       "original": {
         "type": "tarball",
-        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
+        "url": "https://channels.nixos.org/nixos-unstable-small/nixexprs.tar.xz"
       }
     },
     "nixpkgs_2": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,8 @@
 
   inputs = {
 
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
-    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable-small";
+    nixpkgs.url = "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz";
+    nixpkgs-unstable.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
 
     komapedia = {
       url = "github:Die-KoMa/mediawiki";

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
   inputs = {
 
     nixpkgs.url = "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz";
-    nixpkgs-unstable.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
+    nixpkgs-unstable.url = "https://channels.nixos.org/nixos-unstable-small/nixexprs.tar.xz";
 
     komapedia = {
       url = "github:Die-KoMa/mediawiki";

--- a/modules/acme.nix
+++ b/modules/acme.nix
@@ -67,7 +67,7 @@ mkModule {
       certs.${cfg.defaultCertName} = {
         inherit (cfg) extraDomainNames;
         dnsProvider = "desec";
-        credentialFiles.DESECT_TOKEN_FILE = config.sops.secrets.${cfg.sopsCredentialsFile}.path;
+        credentialFiles.DESEC_TOKEN_FILE = config.sops.secrets.${cfg.sopsCredentialsFile}.path;
         postRun = mkIf (length cfg.reloadUnits > 0) ''
           systemctl reload-or-restart ${concatStringsSep " " cfg.reloadUnits}
         '';

--- a/modules/acme.nix
+++ b/modules/acme.nix
@@ -67,7 +67,7 @@ mkModule {
       certs.${cfg.defaultCertName} = {
         inherit (cfg) extraDomainNames;
         dnsProvider = "desec";
-        credentialsFile = config.sops.secrets.${cfg.sopsCredentialsFile}.path;
+        credentialFiles.DESECT_TOKEN_FILE = config.sops.secrets.${cfg.sopsCredentialsFile}.path;
         postRun = mkIf (length cfg.reloadUnits > 0) ''
           systemctl reload-or-restart ${concatStringsSep " " cfg.reloadUnits}
         '';

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -77,7 +77,7 @@ mkTrivialModule {
     export PATH
   '';
 
-  documentation.man.generateCaches = mkDefault true;
+  documentation.man.cache.enable = mkDefault true;
 
   nix = {
     gc = {

--- a/modules/nextcloud.nix
+++ b/modules/nextcloud.nix
@@ -76,7 +76,7 @@ mkTrivialModule {
 
   services.nextcloud =
     let
-      package = pkgs.nextcloud32;
+      package = pkgs.nextcloud33;
     in
     {
       enable = true;

--- a/modules/stalwart-mail.nix
+++ b/modules/stalwart-mail.nix
@@ -31,8 +31,9 @@ mkModule {
       managementURL = "[::1]:${toString cfg.managementPort}";
     in
     {
-      services.stalwart-mail = {
+      services.stalwart = {
         enable = true;
+        stateVersion = "25.11";
         openFirewall = true;
         settings = {
           server = {
@@ -44,6 +45,7 @@ mkModule {
               smtp = {
                 protocol = "smtp";
                 bind = "[::]:25";
+                tls.enable = true;
               };
               submission = {
                 protocol = "smtp";
@@ -94,7 +96,7 @@ mkModule {
       systemd.services.stalwart-mail = {
         reload =
           let
-            stalwart-cli = "${config.services.stalwart-mail.package}/bin/stalwart-cli";
+            stalwart-cli = "${config.services.stalwart.package}/bin/stalwart-cli";
           in
           ''
             export URL=http://${managementURL}
@@ -105,7 +107,7 @@ mkModule {
         restartIfChanged = true;
       };
 
-      wat.KoMa.acme.reloadUnits = [ "stalwart-mail.service" ];
+      wat.KoMa.acme.reloadUnits = [ "stalwart.service" ];
 
     };
 }


### PR DESCRIPTION
Stalwart and ACME needed a bit of attention, I took the changes from my own config. In particular, stalwart doesn't set `listeners.smtp.tls.enable = true` by default anymore, but this is required for STARTTLS support on port 25.

The mediawiki module triggers a spurious warning, cf. NixOS/nixpkgs/pull/533640:
```
warning: The services.mediawiki.database.tablePrefix option has no effect when the services.mediawiki.database.type is not "mysql".
```